### PR TITLE
Restricting Inhumen Worshippers from Certain Roles

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -10,6 +10,7 @@
 
 	allowed_races = RACES_SHUNNED_UP
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 
 	tutorial = "Servitude unto death; That is your motto. Having nurtured royalty for years, you are nothing short of the Duke's majordomo, commanding over the rest of the house staff."
 

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -9,6 +9,7 @@
 	allowed_races = RACES_TOLERATED_UP
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_COUNCILLOR
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "You may have inherited this role, bought your way into it, or were appointed by the Duke themselves; \
 			Regardless of origin, you now serve as an assistant, planner, and juror for the Duke. \
 			You help him oversee the taxation, construction, and planning of new laws. \

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -7,6 +7,7 @@
 	spawn_positions = 1
 
 	allowed_races = RACES_NEARLY_ALL_PLUS_SEELIE
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 
 	tutorial = "The Grenzelhofts were known for their Jesters, wisemen with a tongue just as sharp as their wit. \
 		You command a position of a fool, envious of the position your superiors have upon you. \

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -8,6 +8,9 @@
 
 	allowed_races = RACES_TOLERATED_UP
 	allowed_sexes = list(MALE, FEMALE)
+	allowed_patrons = list(
+		/datum/patron/divine/noc
+	)
 	spells = list(SPELL_LEARNSPELL, SPELL_PRESTIDIGITATION)
 	display_order = JDO_MAGICIAN
 	tutorial = "Your creed is one dedicated to the conquering of the arcane arts and the constant thrill of knowledge. \

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -8,6 +8,9 @@
 
 	allowed_races = RACES_TOLERATED_UP
 	allowed_sexes = list(MALE, FEMALE)
+	allowed_patrons = list(
+		/datum/patron/divine/pestra
+	)
 	display_order = JDO_PHYSICIAN
 	tutorial = "You were a child born into good wealth - But poor health. \
 		Perhaps in another life, you would have turned out to be a powerful mage, wise archivist or a shrewd steward, \

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -9,6 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_VERY_SHUNNED_UP
 	allowed_ages = ALL_AGES_LIST
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "Either a fresh lowborn recruit or a veteran of the now defunct bog guard, you have been assigned to the newly established Vanguard. \
 	You have a roof over your head, coin in your pocket, and a thankless job protecting the outskirts of town against what lurks beyond.\
 	The Bastion must not fall."

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -8,14 +8,16 @@
 
 	allowed_races = RACES_VERY_SHUNNED_UP
 	allowed_sexes = list(MALE, FEMALE)
-
+	allowed_patrons = list(
+		/datum/patron/divine/necra
+	)
 	display_order = JDO_DUNGEONEER
 
 	tutorial = "Sometimes at night you stare into the vacant room and feel the loneliness of your existence crawl into whatever remains of your loathsome soul. \
 	You will never know hunger, thirst or want as long as you stay obedient to your Lord: \
 	Just as you’ll never forget the sounds a saw makes cutting through the bone, what a drowning man will gurgle out between the blood and teeth strangling his breath. \
 	You’re a terrible person, and the carriagemen are going to enjoy walking you down that lonesome path to hell. \
-	Only three things command you on this wretched plane, Necra, Mammon, and the Marshal. "
+	Only two things command you on this wretched plane, Necra and the Bailiff."
 
 	outfit = /datum/outfit/job/roguetown/dungeoneer
 	give_bank_account = 98

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms/manorguard.dm
@@ -9,6 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the Royal Family and their Court, \
 				trained regularly in combat and siege warfare you stand a small chance of surviving the Duke's reign. \
 				It's an honor to die as part of His Highness' retinue, the Marshal reminds you every night."

--- a/code/modules/jobs/job_types/roguetown/garrison/mayor.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/mayor.dm
@@ -9,6 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "Whether you are a crooked politician or a true benefactor, the cityfolk now turn to you for guidance on smaller matters. \
 				The Duke may hold the official title, but with the Sheriff under your command, will you submit to the weight of tradition or reshape the very idea of authority?"
 	whitelist_req = TRUE

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -8,6 +8,7 @@
 
 	allowed_sexes = list(MALE, FEMALE) //same as town guard
 	allowed_races = RACES_SHUNNED_UP // same as town guard
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "You've known combat your entire life. \
 	There isn't a way to kill a man you havent practiced in the tapestries of war itself. \
 	You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. \

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -9,6 +9,7 @@
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Ruler's most trusted confidant and likely friend throughout your marriage. Your loyalty and, perhaps, love; will be tested this day. For the daggers that threaten your beloved are as equally pointed at your own throat."
 
 	spells = list(SPELL_CONVERT_ROLE_SERVANT)

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -6,6 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_SHUNNED_UP_PLUS_SEELIE
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/hand
 	display_order = JDO_HAND

--- a/code/modules/jobs/job_types/roguetown/nobility/ruler.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/ruler.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	spawn_positions = 1
 	selection_color = JCOLOR_NOBLE
 	allowed_races = RACES_TOLERATED_UP
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 
 	spells = list(

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -8,6 +8,7 @@
 
 	allowed_races = RACES_TOLERATED_UP
 	allowed_sexes = list(MALE, FEMALE)
+	allowed_patrons = ALL_NON_INHUMEN_PATRONS
 	display_order = JDO_STEWARD
 	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Duke's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy alive along with your merchant business partner, they're the only two things you can weigh any trust into anymore."
 	outfit = /datum/outfit/job/roguetown/steward

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,5 +1,5 @@
 #ifndef TESTING
-//    #define FASTLOAD
+    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif


### PR DESCRIPTION
Inhumen Patron worshippers now restricted from important gameplay roles, that wouldn't make sense for them to be Inhumen worshippers.